### PR TITLE
#0001-FixJoinIssue - Fix recursive function not returning all join tables

### DIFF
--- a/src/Manipulation/JoinQuery.php
+++ b/src/Manipulation/JoinQuery.php
@@ -318,8 +318,8 @@ class JoinQuery
     {
         $joins = $this->joins;
 
-        foreach ($this->joins as $joins) {
-            foreach ($joins as $join) {
+        foreach ($this->joins as $sub_joins) {
+            foreach ($sub_joins as $join) {
                 $joins = \array_merge($joins, $join->getAllJoins());
             }
         }

--- a/src/Manipulation/JoinQuery.php
+++ b/src/Manipulation/JoinQuery.php
@@ -316,11 +316,11 @@ class JoinQuery
      */
     public function getAllJoins()
     {
-        $joins = $this->joins;
+        $joins = [];
 
         foreach ($this->joins as $sub_joins) {
             foreach ($sub_joins as $join) {
-                $joins = \array_merge($joins, $join->getAllJoins());
+                $joins = \array_merge($joins, [$join], $join->getAllJoins());
             }
         }
 


### PR DESCRIPTION
The fix here is that the returned array `$joins` is the same variable named used in the first `foreach`, which overwrites the joined results for each iteration of the array